### PR TITLE
Fixing and improving the JSON objects mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "node >= 0.10.0"
   ],
   "dependencies": {
+    "lodash.zipobject": "^4.1.3",
     "request": "~2"
   }
 }

--- a/streams.js
+++ b/streams.js
@@ -1,6 +1,7 @@
 
 var util = require('util');
 var stream = require('stream');
+var zipObject = require('lodash.zipobject');
 
 // Split lines
 var Split = function () {
@@ -62,7 +63,11 @@ util.inherits(JSONstream, stream.Transform);
 JSONstream.prototype._transform = function (chunk, encoding, callback) {
 	try {
 		if (chunk) {
-			this.push(JSON.parse(chunk));
+			if (this.headers) {
+				this.push(zipObject(this.headers, JSON.parse(chunk)));
+			} else {
+				this.headers = JSON.parse(chunk);
+			}
 		}
 		callback();
 	} catch (error) {

--- a/streams.js
+++ b/streams.js
@@ -52,14 +52,14 @@ Stringified.prototype._flush = function (callback) {
 };
 
 // Output JSON objects
-var JSON = function () {
+var JSONstream = function () {
 	stream.Transform.call(this);
 	this._readableState.objectMode = true;
 };
 
-util.inherits(JSON, stream.Transform);
+util.inherits(JSONstream, stream.Transform);
 
-JSON.prototype._transform = function (chunk, encoding, callback) {
+JSONstream.prototype._transform = function (chunk, encoding, callback) {
 	try {
 		if (chunk) {
 			this.push(JSON.parse(chunk));
@@ -72,6 +72,6 @@ JSON.prototype._transform = function (chunk, encoding, callback) {
 
 module.exports = {
 	split: Split,
-	json: JSON,
+	json: JSONstream,
 	stringified: Stringified,
 };


### PR DESCRIPTION
Hi mrkishi, I've been trying to use this to bulk export list members and found 2 things:
* The JSON mode fails with an error. The standard `JSON` object is overwritten when the transform stream class in question is itself named `JSON`. It therefore can't find the standard function `JSON.parse()`.
* With that fixed, it returned arrays rather than objects. The first contains column headings. Later chunks contain arrays of values, but not as named properties.

This PR changes the JSON mode to return objects, with properties named according to the first line returned from the API. For example:
```
{
  "Email Address": "example@example.com",
  "First Name": "John",
  "Last Name": "Doe",
  "MEMBER_RATING": 5,
  "OPTIN_TIME": "2016-09-16 17:09:14",
  "OPTIN_IP": null,
  "CONFIRM_TIME": "2016-09-16 17:09:14",
  "CONFIRM_IP": "0.0.0.0",
  "LATITUDE": "0.0000000",
  "LONGITUDE": "0.0000000",
  "GMTOFF": "0",
  "DSTOFF": "1",
  "TIMEZONE": "Atlantic/Faroe",
  "CC": "UK",
  "REGION": "MAN",
  "LAST_CHANGED": "2016-09-16 17:09:14",
  "LEID": "000000000",
  "EUID": "ffffffffff",
  "NOTES": null
}
```

This is however a breaking change to this mode so it might be better off retaining the (fixed) arrays mode, and calling this objects mode something different.